### PR TITLE
Missing "dispatch" method in Stub class

### DIFF
--- a/src/Stub/Dispatcher.php
+++ b/src/Stub/Dispatcher.php
@@ -279,4 +279,17 @@ class Dispatcher implements DispatcherContract
     public function setQueueResolver(callable $resolver)
     {
     }
+
+	/**
+	 * Fire an event until the first non-null response is returned.
+	 *
+	 * @param  string|object $event
+	 * @param  mixed         $payload
+	 * @param  bool          $halt
+	 *
+	 * @return array|null
+	 */
+	public function dispatch($event, $payload = [], $halt = false)
+	{
+	}
 }


### PR DESCRIPTION
There was a major bug in the Moon\Artisan\Stub\Dispatcher class. This class implements DispatcherContract interface but there was a method that was not implemented in Dispatcher class, so this PR solves that. 

This issue avoid that makes the library works, so it's a critical issue. Please merge this ASAP.

Regards